### PR TITLE
BUG: Automatically pass self for server method calls (virtual_text)

### DIFF
--- a/lua/codeium/virtual_text.lua
+++ b/lua/codeium/virtual_text.lua
@@ -171,7 +171,7 @@ local function completion_inserter(current_completion, insert_text)
 
 	local cursor_text = delta == 0 and "" or '<C-O>:exe "go" line2byte(line("."))+col(".")+(' .. delta .. ")<CR>"
 
-	server.accept_completion(current_completion.completion.completionId)
+	server:accept_completion(current_completion.completion.completionId)
 
 	return '<C-g>u' .. delete_range .. insert_text .. cursor_text
 end
@@ -438,7 +438,7 @@ function M.complete(opts)
 
 	codeium_status = "waiting"
 
-	local cancel = server.request_completion(
+	local cancel = server:request_completion(
 		data.document,
 		data.editor_options,
 		data.other_documents,

--- a/lua/codeium/virtual_text.lua
+++ b/lua/codeium/virtual_text.lua
@@ -484,7 +484,7 @@ end
 
 function M.debounced_complete()
 	M.clear()
-	if config.options.virtual_text.manual or not server.is_healthy() or not M.filetype_enabled(vim.fn.bufnr("")) then
+	if config.options.virtual_text.manual or not server:is_healthy() or not M.filetype_enabled(vim.fn.bufnr("")) then
 		return
 	end
 	local current_buf = vim.fn.bufnr("")


### PR DESCRIPTION
Fixes #298 

## Summary
Function in Lua require `:` instead of `.` to pass self automatically.
This PR fixes it by swapping the `.` with `:` as necessary to fix the error.

See https://www.lua.org/manual/5.1/manual.html#2.5.8 for more.
> A call v:name(args) is syntactic sugar for v.name(v,args), except that v is evaluated only once. 

## Does it work? Yes
Completions now happen successfully (prior behavior can be observed in #298)
![image](https://github.com/user-attachments/assets/4e00a593-46e1-425c-a8f2-0afe64ea0fe0)
